### PR TITLE
Re-onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.4")
+@Library("Infrastructure@cve-dashboard")
 
 def type = "java"
 def product = "lau"
@@ -35,6 +35,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withPipeline(type, product, component) {
+    enableCveDashboardIngestion()
     env.TEST_URL = 'http://lau-eud-backend-aat.service.core-compute-aat.internal'
 
     loadVaultSecrets(secrets)


### PR DESCRIPTION
## Summary
- pin the shared Jenkins library to cve-dashboard, now based on version 2.4.9
- enable CVE dashboard ingestion

## Testing
- Jenkinsfile-only configuration change